### PR TITLE
Simplify auth setup

### DIFF
--- a/sdk/go/api_esc_extensions.go
+++ b/sdk/go/api_esc_extensions.go
@@ -15,6 +15,16 @@ type EscClient struct {
 	EscAPI    *EscAPIService
 }
 
+func NewAuthContext(apiKey string) context.Context {
+	return context.WithValue(
+		context.Background(),
+		ContextAPIKeys,
+		map[string]APIKey{
+			"Authorization": {Key: apiKey, Prefix: "token"},
+		},
+	)
+}
+
 func NewClient(cfg *Configuration) *EscClient {
 	client := &EscClient{rawClient: NewRawAPIClient(cfg)}
 	client.EscAPI = client.rawClient.EscAPI

--- a/sdk/go/api_esc_test.go
+++ b/sdk/go/api_esc_test.go
@@ -30,13 +30,7 @@ func Test_EscClient(t *testing.T) {
 	require.NotEmpty(t, orgName, "PULUMI_ORG must be set")
 	configuration := NewConfiguration()
 	apiClient := NewClient(configuration)
-	auth := context.WithValue(
-		context.Background(),
-		ContextAPIKeys,
-		map[string]APIKey{
-			"Authorization": {Key: accessToken, Prefix: "token"},
-		},
-	)
+	auth := NewAuthContext(accessToken)
 
 	removeAllGoTestEnvs(t, apiClient, auth, orgName)
 

--- a/sdk/python/pulumi_esc_sdk/configuration.py
+++ b/sdk/python/pulumi_esc_sdk/configuration.py
@@ -82,8 +82,6 @@ conf = pulumi_esc_sdk.Configuration(
     _default = None
 
     def __init__(self, host=None,
-                 api_key=None, api_key_prefix=None,
-                 username=None, password=None,
                  access_token=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
@@ -107,26 +105,13 @@ conf = pulumi_esc_sdk.Configuration(
         """
         # Authentication Settings
         self.api_key = {}
-        if api_key:
-            self.api_key = api_key
+        if access_token:
+            self.api_key['Authorization'] = access_token
         """dict to store API key(s)
         """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
-        """
+        self.api_key_prefix = { 'Authorization': 'token' }
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
-        """
-        self.username = username
-        """Username for HTTP basic authentication
-        """
-        self.password = password
-        """Password for HTTP basic authentication
-        """
-        self.access_token = access_token
-        """Access token
         """
         self.logger = {}
         """Logging Settings

--- a/sdk/python/pulumi_esc_sdk/esc_client.py
+++ b/sdk/python/pulumi_esc_sdk/esc_client.py
@@ -4,6 +4,8 @@
 from pulumi_esc_sdk.exceptions import ApiException
 import pulumi_esc_sdk.models as models
 import pulumi_esc_sdk.api as api
+import pulumi_esc_sdk.configuration as configuration
+import pulumi_esc_sdk.api_client as api_client
 from pydantic import StrictBytes, StrictInt
 from typing import Mapping, Any, List
 import inspect
@@ -16,8 +18,8 @@ class EscClient:
 
     :param esc_api: EscApi (required)
     """
-    def __init__(self, esc_api: api.EscApi) -> None:
-        self.esc_api = esc_api
+    def __init__(self, configuration: configuration.Configuration) -> None:
+        self.esc_api = api.EscApi(api_client.ApiClient(configuration))
 
     def list_environments(self, org_name: str, continuation_token: str = None) -> models.OrgEnvironments:
         return self.esc_api.list_environments(org_name, continuation_token)

--- a/sdk/python/test/test_esc_api.py
+++ b/sdk/python/test/test_esc_api.py
@@ -21,10 +21,8 @@ class TestEscApi(unittest.TestCase):
         self.orgName = os.getenv("PULUMI_ORG")
         self.assertIsNotNone(self.orgName, "PULUMI_ORG must be set")
 
-        configuration = esc.Configuration()
-        configuration.api_key['Authorization'] = "token " + self.accessToken
-        self.apiClient = esc.ApiClient(configuration)
-        self.client = esc.EscClient(esc.EscApi(self.apiClient))
+        configuration = esc.Configuration(access_token=self.accessToken)
+        self.client = esc.EscClient(configuration)
 
         self.remove_all_python_test_envs()
 

--- a/sdk/templates/python/configuration.mustache
+++ b/sdk/templates/python/configuration.mustache
@@ -139,8 +139,6 @@ conf = {{{packageName}}}.Configuration(
     _default = None
 
     def __init__(self, host=None,
-                 api_key=None, api_key_prefix=None,
-                 username=None, password=None,
                  access_token=None,
 {{#hasHttpSignatureMethods}}
                  signing_info=None,
@@ -167,26 +165,13 @@ conf = {{{packageName}}}.Configuration(
         """
         # Authentication Settings
         self.api_key = {}
-        if api_key:
-            self.api_key = api_key
+        if access_token:
+            self.api_key['Authorization'] = access_token
         """dict to store API key(s)
         """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
-        """
+        self.api_key_prefix = { 'Authorization': 'token' }
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
-        """
-        self.username = username
-        """Username for HTTP basic authentication
-        """
-        self.password = password
-        """Password for HTTP basic authentication
-        """
-        self.access_token = access_token
-        """Access token
         """
 {{#hasHttpSignatureMethods}}
         if signing_info is not None:

--- a/sdk/templates/typescript/api.mustache
+++ b/sdk/templates/typescript/api.mustache
@@ -16,7 +16,7 @@ import FormData from 'form-data'
 {{/withNodeImports}}
 // Some imports not used depending on template conditions
 // @ts-ignore
-import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
+import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 import type { RequestArgs } from './base';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerMap } from './base';

--- a/sdk/templates/typescript/apiInner.mustache
+++ b/sdk/templates/typescript/apiInner.mustache
@@ -16,7 +16,7 @@ import FormData from 'form-data'
 {{/withNodeImports}}
 // Some imports not used depending on template conditions
 // @ts-ignore
-import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '{{apiRelativeToRoot}}common';
+import { DUMMY_BASE_URL, assertParamExists, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '{{apiRelativeToRoot}}common';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError, operationServerMap } from '{{apiRelativeToRoot}}base';
 {{#imports}}

--- a/sdk/templates/typescript/common.mustache
+++ b/sdk/templates/typescript/common.mustache
@@ -27,6 +27,34 @@ export const assertParamExists = function (functionName: string, paramName: stri
     }
 }
 
+/**
+ *
+ * @export
+ */
+export const setApiKeyToObject = async function (object: any, keyParamName: string, configuration?: Configuration) {
+    if (configuration && configuration.accessToken) { // override to access token because that is more correct for Pulumi auth
+        let localVarApiKeyValue = typeof configuration.accessToken === 'function'
+            ? await configuration.accessToken(keyParamName)
+            : await configuration.accessToken;
+        if (!localVarApiKeyValue.startsWith('token')) {
+            localVarApiKeyValue = 'token ' + localVarApiKeyValue;
+        }
+        object[keyParamName] = localVarApiKeyValue;
+    }
+}
+
+/**
+ *
+ * @export
+ */
+export const setBearerAuthToObject = async function (object: any, configuration?: Configuration) {
+    if (configuration && configuration.accessToken) {
+        const accessToken = typeof configuration.accessToken === 'function'
+            ? await configuration.accessToken()
+            : await configuration.accessToken;
+        object["Authorization"] = "Bearer " + accessToken;
+    }
+}
 
 /**
  *
@@ -37,7 +65,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
         const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
             ? await configuration.accessToken(name, scopes)
             : await configuration.accessToken;
-        object["Authorization"] = configuration.tokenPrefix + localVarAccessTokenValue;
+        object["Authorization"] = "Bearer " + localVarAccessTokenValue;
     }
 }
 

--- a/sdk/templates/typescript/common.mustache
+++ b/sdk/templates/typescript/common.mustache
@@ -36,8 +36,8 @@ export const setApiKeyToObject = async function (object: any, keyParamName: stri
         let localVarApiKeyValue = typeof configuration.accessToken === 'function'
             ? await configuration.accessToken(keyParamName)
             : await configuration.accessToken;
-        if (!localVarApiKeyValue.startsWith('token')) {
-            localVarApiKeyValue = 'token ' + localVarApiKeyValue;
+        if (!localVarApiKeyValue.startsWith(configuration.tokenPrefix)) {
+            localVarApiKeyValue = configuration.tokenPrefix + ' ' + localVarApiKeyValue;
         }
         object[keyParamName] = localVarApiKeyValue;
     }

--- a/sdk/templates/typescript/common.mustache
+++ b/sdk/templates/typescript/common.mustache
@@ -27,41 +27,6 @@ export const assertParamExists = function (functionName: string, paramName: stri
     }
 }
 
-/**
- *
- * @export
- */
-export const setApiKeyToObject = async function (object: any, keyParamName: string, configuration?: Configuration) {
-    if (configuration && configuration.apiKey) {
-        const localVarApiKeyValue = typeof configuration.apiKey === 'function'
-            ? await configuration.apiKey(keyParamName)
-            : await configuration.apiKey;
-        object[keyParamName] = localVarApiKeyValue;
-    }
-}
-
-/**
- *
- * @export
- */
-export const setBasicAuthToObject = function (object: any, configuration?: Configuration) {
-    if (configuration && (configuration.username || configuration.password)) {
-        object["auth"] = { username: configuration.username, password: configuration.password };
-    }
-}
-
-/**
- *
- * @export
- */
-export const setBearerAuthToObject = async function (object: any, configuration?: Configuration) {
-    if (configuration && configuration.accessToken) {
-        const accessToken = typeof configuration.accessToken === 'function'
-            ? await configuration.accessToken()
-            : await configuration.accessToken;
-        object["Authorization"] = "Bearer " + accessToken;
-    }
-}
 
 /**
  *
@@ -72,7 +37,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
         const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
             ? await configuration.accessToken(name, scopes)
             : await configuration.accessToken;
-        object["Authorization"] = "Bearer " + localVarAccessTokenValue;
+        object["Authorization"] = configuration.tokenPrefix + localVarAccessTokenValue;
     }
 }
 

--- a/sdk/templates/typescript/configuration.mustache
+++ b/sdk/templates/typescript/configuration.mustache
@@ -3,9 +3,6 @@
 {{>licenseInfo}}
 
 export interface ConfigurationParameters {
-    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
-    username?: string;
-    password?: string;
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
     basePath?: string;
     serverIndex?: number;
@@ -15,32 +12,13 @@ export interface ConfigurationParameters {
 
 export class Configuration {
     /**
-     * parameter for apiKey security
-     * @param name security name
-     * @memberof Configuration
-     */
-    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
-    /**
-     * parameter for basic security
-     *
-     * @type {string}
-     * @memberof Configuration
-     */
-    username?: string;
-    /**
-     * parameter for basic security
-     *
-     * @type {string}
-     * @memberof Configuration
-     */
-    password?: string;
-    /**
      * parameter for oauth2 security
      * @param name security name
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
+    tokenPrefix: string;
     /**
      * override base path
      *
@@ -72,14 +50,12 @@ export class Configuration {
     formDataCtor?: new () => any;
 
     constructor(param: ConfigurationParameters = {}) {
-        this.apiKey = param.apiKey;
-        this.username = param.username;
-        this.password = param.password;
         this.accessToken = param.accessToken;
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = param.baseOptions;
         this.formDataCtor = param.formDataCtor;
+        this.tokenPrefix = 'token';
     }
 
     /**

--- a/sdk/templates/typescript/configuration.mustache
+++ b/sdk/templates/typescript/configuration.mustache
@@ -18,7 +18,15 @@ export class Configuration {
      * @memberof Configuration
      */
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
+
+    /**
+     * token prefix, hard coded to 'token'
+     *
+     * @type {string}
+     * @memberof Configuration
+     */
     tokenPrefix: string;
+
     /**
      * override base path
      *

--- a/sdk/typescript/esc/raw/api.ts
+++ b/sdk/typescript/esc/raw/api.ts
@@ -20,7 +20,7 @@ import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
-import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
+import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 import type { RequestArgs } from './base';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerMap } from './base';

--- a/sdk/typescript/esc/raw/common.ts
+++ b/sdk/typescript/esc/raw/common.ts
@@ -37,41 +37,6 @@ export const assertParamExists = function (functionName: string, paramName: stri
     }
 }
 
-/**
- *
- * @export
- */
-export const setApiKeyToObject = async function (object: any, keyParamName: string, configuration?: Configuration) {
-    if (configuration && configuration.apiKey) {
-        const localVarApiKeyValue = typeof configuration.apiKey === 'function'
-            ? await configuration.apiKey(keyParamName)
-            : await configuration.apiKey;
-        object[keyParamName] = localVarApiKeyValue;
-    }
-}
-
-/**
- *
- * @export
- */
-export const setBasicAuthToObject = function (object: any, configuration?: Configuration) {
-    if (configuration && (configuration.username || configuration.password)) {
-        object["auth"] = { username: configuration.username, password: configuration.password };
-    }
-}
-
-/**
- *
- * @export
- */
-export const setBearerAuthToObject = async function (object: any, configuration?: Configuration) {
-    if (configuration && configuration.accessToken) {
-        const accessToken = typeof configuration.accessToken === 'function'
-            ? await configuration.accessToken()
-            : await configuration.accessToken;
-        object["Authorization"] = "Bearer " + accessToken;
-    }
-}
 
 /**
  *
@@ -82,7 +47,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
         const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
             ? await configuration.accessToken(name, scopes)
             : await configuration.accessToken;
-        object["Authorization"] = "Bearer " + localVarAccessTokenValue;
+        object["Authorization"] = configuration.tokenPrefix + localVarAccessTokenValue;
     }
 }
 

--- a/sdk/typescript/esc/raw/common.ts
+++ b/sdk/typescript/esc/raw/common.ts
@@ -46,8 +46,8 @@ export const setApiKeyToObject = async function (object: any, keyParamName: stri
         let localVarApiKeyValue = typeof configuration.accessToken === 'function'
             ? await configuration.accessToken(keyParamName)
             : await configuration.accessToken;
-        if (!localVarApiKeyValue.startsWith('token')) {
-            localVarApiKeyValue = 'token ' + localVarApiKeyValue;
+        if (!localVarApiKeyValue.startsWith(configuration.tokenPrefix)) {
+            localVarApiKeyValue = configuration.tokenPrefix + ' ' + localVarApiKeyValue;
         }
         object[keyParamName] = localVarApiKeyValue;
     }

--- a/sdk/typescript/esc/raw/common.ts
+++ b/sdk/typescript/esc/raw/common.ts
@@ -37,6 +37,34 @@ export const assertParamExists = function (functionName: string, paramName: stri
     }
 }
 
+/**
+ *
+ * @export
+ */
+export const setApiKeyToObject = async function (object: any, keyParamName: string, configuration?: Configuration) {
+    if (configuration && configuration.accessToken) { // override to access token because that is more correct for Pulumi auth
+        let localVarApiKeyValue = typeof configuration.accessToken === 'function'
+            ? await configuration.accessToken(keyParamName)
+            : await configuration.accessToken;
+        if (!localVarApiKeyValue.startsWith('token')) {
+            localVarApiKeyValue = 'token ' + localVarApiKeyValue;
+        }
+        object[keyParamName] = localVarApiKeyValue;
+    }
+}
+
+/**
+ *
+ * @export
+ */
+export const setBearerAuthToObject = async function (object: any, configuration?: Configuration) {
+    if (configuration && configuration.accessToken) {
+        const accessToken = typeof configuration.accessToken === 'function'
+            ? await configuration.accessToken()
+            : await configuration.accessToken;
+        object["Authorization"] = "Bearer " + accessToken;
+    }
+}
 
 /**
  *
@@ -47,7 +75,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
         const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
             ? await configuration.accessToken(name, scopes)
             : await configuration.accessToken;
-        object["Authorization"] = configuration.tokenPrefix + localVarAccessTokenValue;
+        object["Authorization"] = "Bearer " + localVarAccessTokenValue;
     }
 }
 

--- a/sdk/typescript/esc/raw/configuration.ts
+++ b/sdk/typescript/esc/raw/configuration.ts
@@ -31,7 +31,15 @@ export class Configuration {
      * @memberof Configuration
      */
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
+
+    /**
+     * token prefix, hard coded to 'token'
+     *
+     * @type {string}
+     * @memberof Configuration
+     */
     tokenPrefix: string;
+
     /**
      * override base path
      *

--- a/sdk/typescript/esc/raw/configuration.ts
+++ b/sdk/typescript/esc/raw/configuration.ts
@@ -16,9 +16,6 @@
 
 
 export interface ConfigurationParameters {
-    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
-    username?: string;
-    password?: string;
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
     basePath?: string;
     serverIndex?: number;
@@ -28,32 +25,13 @@ export interface ConfigurationParameters {
 
 export class Configuration {
     /**
-     * parameter for apiKey security
-     * @param name security name
-     * @memberof Configuration
-     */
-    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
-    /**
-     * parameter for basic security
-     *
-     * @type {string}
-     * @memberof Configuration
-     */
-    username?: string;
-    /**
-     * parameter for basic security
-     *
-     * @type {string}
-     * @memberof Configuration
-     */
-    password?: string;
-    /**
      * parameter for oauth2 security
      * @param name security name
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
+    tokenPrefix: string;
     /**
      * override base path
      *
@@ -85,14 +63,12 @@ export class Configuration {
     formDataCtor?: new () => any;
 
     constructor(param: ConfigurationParameters = {}) {
-        this.apiKey = param.apiKey;
-        this.username = param.username;
-        this.password = param.password;
         this.accessToken = param.accessToken;
         this.basePath = param.basePath;
         this.serverIndex = param.serverIndex;
         this.baseOptions = param.baseOptions;
         this.formDataCtor = param.formDataCtor;
+        this.tokenPrefix = 'token';
     }
 
     /**

--- a/sdk/typescript/test/client.spec.ts
+++ b/sdk/typescript/test/client.spec.ts
@@ -26,8 +26,7 @@ describe("ESC", async () => {
     if (!PULUMI_ORG) {
         throw new Error("PULUMI_ORG not set");
     }
-    let config = new esc.Configuration();
-    config.apiKey = `token ${PULUMI_ACCESS_TOKEN}`;
+    let config = new esc.Configuration({ accessToken: PULUMI_ACCESS_TOKEN });
     const client = new esc.EscApi(config);
     const baseEnvName = `${ENV_PREFIX}-base-${Date.now()}`;
 

--- a/sdk/typescript/test/client.spec.ts
+++ b/sdk/typescript/test/client.spec.ts
@@ -26,7 +26,7 @@ describe("ESC", async () => {
     if (!PULUMI_ORG) {
         throw new Error("PULUMI_ORG not set");
     }
-    let config = new esc.Configuration({ accessToken: PULUMI_ACCESS_TOKEN });
+    const config = new esc.Configuration({ accessToken: PULUMI_ACCESS_TOKEN });
     const client = new esc.EscApi(config);
     const baseEnvName = `${ENV_PREFIX}-base-${Date.now()}`;
 


### PR DESCRIPTION
Simplify the auth setup across all languages.  

The configuration is neccessary to provide specifying url for self hosted and support dynamic token refresh.