### PR TITLE
Add pulumi-plugin.json to mark as non-provider

### DIFF
--- a/sdk/python/pulumi-plugin.json
+++ b/sdk/python/pulumi-plugin.json
@@ -1,0 +1,1 @@
+{ "resource": false }

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -48,5 +48,5 @@ setup(
     long_description="""\
     Pulumi ESC allows you to compose and manage hierarchical collections of configuration and secrets and consume them in various ways.
     """,  # noqa: E501
-    package_data={"pulumi_esc_sdk": ["py.typed"]},
+    package_data={"pulumi_esc_sdk": ["py.typed", "pulumi-plugin.json"]},
 )

--- a/sdk/templates/python/pyproject.mustache
+++ b/sdk/templates/python/pyproject.mustache
@@ -7,7 +7,7 @@ license = "{{{licenseInfo}}}{{^licenseInfo}}NoLicense{{/licenseInfo}}"
 readme = "README.md"
 repository = "https://github.com/{{{gitUserId}}}/{{{gitRepoId}}}"
 keywords = ["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"]
-include = ["{{packageName}}/py.typed"]
+include = ["{{packageName}}/py.typed", "{{packageName}}/pulumi-plugin.json"]
 
 [tool.poetry.dependencies]
 python = "^3.7"

--- a/sdk/templates/python/setup.mustache
+++ b/sdk/templates/python/setup.mustache
@@ -50,7 +50,7 @@ setup(
     long_description="""\
     {{appDescription}}
     """,  # noqa: E501
-    package_data={"{{{packageName}}}": ["py.typed"]},
+    package_data={"{{{packageName}}}": ["py.typed", "pulumi-plugin.json"]},
 )
 {{/-last}}
 {{/apis}}


### PR DESCRIPTION
Fixes https://github.com/pulumi/esc-sdk/issues/33

## Testing

Ran `make build_python`

In a test project, added `/full/path/sdk/python/bin/dist/pulumi_esc_sdk-0.10.0.dev0-py3-none-any.whl` to requirements.txt, ran `pip install -r requirements.txt` and `pulumi install` with no issues

Confirmed that `pulumi-plugin.json` is present in `lib/python3.12/site-packages/pulumi_esc_sdk/`, and confirmed error when file not present