### PR TITLE
Fix pyyaml dependency

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -30,6 +30,7 @@ REQUIRES = [
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",
+    "pyyaml >= 6.0.1",
 ]
 
 setup(

--- a/sdk/templates/python/setup.mustache
+++ b/sdk/templates/python/setup.mustache
@@ -32,6 +32,7 @@ REQUIRES = [
 {{/hasHttpSignatureMethods}}
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",
+    "pyyaml >= 6.0.1",
 ]
 
 setup(


### PR DESCRIPTION
Fixes https://github.com/pulumi/esc-sdk/issues/29
Tested in a local project with `import pulumi_esc_sdk as esc`