### PR TITLE
Fixing panic in go's ReadOpenEnvironment

### DIFF
--- a/sdk/go/api_esc_extensions.go
+++ b/sdk/go/api_esc_extensions.go
@@ -101,6 +101,10 @@ func (c *EscClient) ReadOpenEnvironment(ctx context.Context, org, projectName, e
 		return nil, nil, err
 	}
 
+	if env == nil || env.Properties == nil {
+		return nil, nil, nil
+	}
+
 	propertyMap := *env.Properties
 	for k, v := range propertyMap {
 		v.Value = mapValues(v.Value)

--- a/sdk/go/api_esc_test.go
+++ b/sdk/go/api_esc_test.go
@@ -66,6 +66,11 @@ func Test_EscClient(t *testing.T) {
 		envs, err := apiClient.ListEnvironments(auth, orgName, nil)
 		require.Nil(t, err)
 
+		_, values, err := apiClient.OpenAndReadEnvironment(auth, orgName, PROJECT_NAME, envName)
+		require.Nil(t, err)
+		var nilValues map[string]any = nil
+		require.Equal(t, values, nilValues)
+
 		requireFindEnvironment(t, envs, envName)
 
 		yaml := "imports:\n  - " + PROJECT_NAME + "/" + baseEnvName + "\n" + `
@@ -102,7 +107,7 @@ values:
 		require.True(t, ok)
 		require.Equal(t, "shh! don't tell anyone", mySecret["fn::secret"])
 
-		_, values, err := apiClient.OpenAndReadEnvironment(auth, orgName, PROJECT_NAME, envName)
+		_, values, err = apiClient.OpenAndReadEnvironment(auth, orgName, PROJECT_NAME, envName)
 		require.Nil(t, err)
 
 		require.Equal(t, baseEnvName, values["base"])

--- a/sdk/python/test/test_esc_api.py
+++ b/sdk/python/test/test_esc_api.py
@@ -44,6 +44,9 @@ class TestEscApi(unittest.TestCase):
         envs = self.client.list_environments(self.orgName)
         self.assertFindEnv(envs)
 
+        _, _, yaml = self.client.open_and_read_environment(self.orgName, PROJECT_NAME, self.envName)
+        self.assertEqual(yaml, "{}\n")
+
         fooReference = "${foo}"
         yaml = f"""
 imports:

--- a/sdk/typescript/test/client.spec.ts
+++ b/sdk/typescript/test/client.spec.ts
@@ -53,6 +53,10 @@ describe("ESC", async () => {
         assert.notEqual(orgs, undefined);
         assert(orgs?.environments?.some((e) => e.name === name));
 
+        let openEmptyEnv = await client.openAndReadEnvironment(PULUMI_ORG, PROJECT_NAME, name);
+        assert.deepEqual(openEmptyEnv?.environment, {})
+        assert.deepEqual(openEmptyEnv?.values, {})
+
         const envDef: esc.EnvironmentDefinition = {
             imports: [fullyQualifiedName(baseEnvName)],
             values: {


### PR DESCRIPTION
### Summary
- Adding a nil check in go's ReadOpenEnvironment method
- Adding tests to avoid this issue
- Verified the return is now `{}`, as in CLI and other langs
