### PR TITLE
Fix panic in go when reading invalid env property

### DIFF
--- a/sdk/go/api_esc_extensions.go
+++ b/sdk/go/api_esc_extensions.go
@@ -146,6 +146,10 @@ func (c *EscClient) OpenAndReadEnvironmentAtVersion(ctx context.Context, org, pr
 // The property is returned along with the resolved value.
 func (c *EscClient) ReadEnvironmentProperty(ctx context.Context, org, projectName, envName, openEnvID, propPath string) (*Value, any, error) {
 	prop, _, err := c.EscAPI.ReadOpenEnvironmentProperty(ctx, org, projectName, envName, openEnvID).Property(propPath).Execute()
+	if prop == nil {
+		return nil, nil, err
+	}
+
 	v := mapValuesPrimitive(prop.Value)
 	return prop, v, err
 }


### PR DESCRIPTION
We were running into a nil dereference when retrieving an invalid env property failed. this fix just returns the error early if that happens.

Fixes https://github.com/pulumi/esc-sdk/issues/59