### PR TITLE
build: remove urllib3 max version constraint in requirements.txt

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3
+urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 2
 typing-extensions >= 4.7.1
 pyyaml >= 6.0.1

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 1.25.3
 pydantic >= 2
 typing-extensions >= 4.7.1
 pyyaml >= 6.0.1

--- a/sdk/templates/python/requirements.mustache
+++ b/sdk/templates/python/requirements.mustache
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 1.25.3
 pydantic >= 2
 typing-extensions >= 4.7.1
 {{#asyncio}}


### PR DESCRIPTION
urllib3 had vulnerabilities identified in many old versions.

I propose removing the< 2.1.0 version restriction so that consumers are free to choose a version of urllib3 that has patched the vulnerabilities.

Let me know if there are other areas that need to be changed!