### PR TITLE
Fixing import bug for TS SDK

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,5 +2,8 @@
 
 ### Bug Fixes
 
+- Fixing bad import in TS SDK release
+  [#88](https://github.com/pulumi/esc-sdk/pull/88)
+
 ### Breaking changes
 

--- a/sdk/typescript/esc/index.ts
+++ b/sdk/typescript/esc/index.ts
@@ -23,7 +23,7 @@ import {
 } from "./raw/index";
 import * as yaml from "js-yaml";
 import { AxiosError } from "axios";
-import { getCurrentAccount } from "workspace";
+import { getCurrentAccount } from "./workspace";
 
 export {
     Configuration,


### PR DESCRIPTION
### Summary
- Recently published Typescript SDK errors out when new `DefaultClient` is used with `Error: Cannot find module 'workspace'`
- I investigated the issue, found out that due to this improper import, it works locally when I ran this logic via .spec.ts test files, but when actually published it does not work

### Testing
- Made a new empty node project, added `esc-sdk` node module and tried to run `DefaultClient` - originally failed
- Updated the import, ran `make build_typescript`, then copied the bin folder's files into the test project's `node_modules`, replacing the files
- Now default client creation succeeded

Note: We need to do a patch release once this is in right away.