### PR TITLE
Improving cleanup to remove all leftover cloned environments

### DIFF
--- a/sdk/python/test/test_esc_api.py
+++ b/sdk/python/test/test_esc_api.py
@@ -28,10 +28,7 @@ class TestEscApi(unittest.TestCase):
         self.envName = None
 
     def tearDown(self) -> None:
-        if self.baseEnvName is not None:
-            self.client.delete_environment(self.orgName, PROJECT_NAME, self.baseEnvName)
-        if self.envName is not None:
-            self.client.delete_environment(self.orgName, PROJECT_NAME, self.envName)
+        self.remove_all_python_test_envs()
 
     def test_environment_end_to_end(self) -> None:
         self.envName = f"{ENV_PREFIX}-end-to-end-{datetime.now().timestamp()}"
@@ -190,8 +187,8 @@ values:
         while True:
             envs = self.client.list_environments(self.orgName, continuationToken)
             for env in envs.environments:
-                if env.project == PROJECT_NAME and env.name.startswith(ENV_PREFIX):
-                    self.client.delete_environment(self.orgName, PROJECT_NAME, env.name)
+                if (env.project == PROJECT_NAME or env.project == f"{PROJECT_NAME}-clone") and env.name.startswith(ENV_PREFIX):
+                    self.client.delete_environment(self.orgName, env.project, env.name)
 
             continuationToken = envs.next_token
             if continuationToken is None or continuationToken == "":

--- a/sdk/typescript/test/client.spec.ts
+++ b/sdk/typescript/test/client.spec.ts
@@ -38,7 +38,7 @@ describe("ESC", async () => {
     });
 
     after(async () => {
-        await client.deleteEnvironment(PULUMI_ORG, PROJECT_NAME, baseEnvName);
+        await removeAllTestEnvs(client, PULUMI_ORG);
     });
 
     it("should create, clone, list, update, get, decrypt, open and delete an environment", async () => {
@@ -224,8 +224,8 @@ async function removeAllTestEnvs(client: esc.EscApi, orgName: string): Promise<a
 
         assert.notEqual(orgs, undefined);
         orgs?.environments?.forEach(async (e: esc.OrgEnvironment) => {
-            if (e.project === PROJECT_NAME && e.name.startsWith(ENV_PREFIX)) {
-                await client.deleteEnvironment(orgName, PROJECT_NAME, e.name);
+            if ((e.project === PROJECT_NAME || e.project === `${PROJECT_NAME}-clone`) && e.name.startsWith(ENV_PREFIX)) {
+                await client.deleteEnvironment(orgName, e.project, e.name);
             }
         });
 


### PR DESCRIPTION
### Summary
- We have (now had, after this PR tests ran) ~100 of TS and Py environments each, that are leftover from tests, cluttering pulumi org
<img width="575" alt="image" src="https://github.com/user-attachments/assets/3b160c88-6022-449b-b9fd-4793b1926f48" />

- This will clean them up and ensure they're cleaned up from now on

### Testing
- Cleaned up my review stack that had a similar problem from all the testing