### PR TITLE
build: drop urllib max constraint from setup.py template

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -26,7 +26,7 @@ NAME = "pulumi-esc-sdk"
 VERSION = "0.12.1.dev.0"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 1.25.3",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/sdk/templates/python/setup.mustache
+++ b/sdk/templates/python/setup.mustache
@@ -17,7 +17,7 @@ PYTHON_REQUIRES = ">=3.7"
 {{#apis}}
 {{#-last}}
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 1.25.3",
     "python-dateutil",
 {{#asyncio}}
     "aiohttp >= 3.0.0",


### PR DESCRIPTION
#70 dropped this constraint, but it was accidentally left in place in the setup.py template, so built wheels are still reporting it unintentionally.
