### PR TITLE
Add support for http_proxy and no_proxy env variables on python sdk

### DIFF
--- a/sdk/templates/python/configuration.mustache
+++ b/sdk/templates/python/configuration.mustache
@@ -8,11 +8,99 @@ from logging import FileHandler
 {{^asyncio}}
 import multiprocessing
 {{/asyncio}}
+import os
 import sys
-from typing import Optional
+from typing import Optional, List
 import urllib3
+from urllib.parse import urlparse
 
 import http.client as httplib
+
+
+def _get_proxy_from_environment(url: str) -> Optional[str]:
+    """Get the appropriate proxy URL from environment variables.
+
+    Checks HTTPS_PROXY/https_proxy for HTTPS URLs,
+    HTTP_PROXY/http_proxy for HTTP URLs.
+
+    :param url: The target URL to get proxy for.
+    :return: The proxy URL or None if no proxy is configured.
+    """
+    if url is None:
+        return None
+
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower() if parsed.scheme else 'https'
+
+    if scheme == 'https':
+        proxy = os.environ.get('HTTPS_PROXY') or os.environ.get('https_proxy')
+    else:
+        proxy = os.environ.get('HTTP_PROXY') or os.environ.get('http_proxy')
+
+    # Fall back to generic proxy
+    if not proxy:
+        proxy = os.environ.get('ALL_PROXY') or os.environ.get('all_proxy')
+
+    return proxy
+
+
+def _get_no_proxy_from_environment() -> List[str]:
+    """Get the no_proxy list from environment variables.
+
+    :return: List of hosts/patterns that should bypass the proxy.
+    """
+    no_proxy = os.environ.get('NO_PROXY') or os.environ.get('no_proxy') or ''
+    if not no_proxy:
+        return []
+    return [host.strip() for host in no_proxy.split(',') if host.strip()]
+
+
+def _should_bypass_proxy(url: str, no_proxy: List[str]) -> bool:
+    """Check if the given URL should bypass the proxy.
+
+    :param url: The target URL.
+    :param no_proxy: List of hosts/patterns that should bypass the proxy.
+    :return: True if the URL should bypass the proxy, False otherwise.
+    """
+    if not no_proxy or not url:
+        return False
+
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        return False
+
+    host = host.lower()
+
+    for pattern in no_proxy:
+        pattern = pattern.lower().strip()
+        if not pattern:
+            continue
+
+        # Special case: '*' means bypass all
+        if pattern == '*':
+            return True
+
+        # Remove leading dot for comparison
+        if pattern.startswith('.'):
+            pattern = pattern[1:]
+
+        # Exact match
+        if host == pattern:
+            return True
+
+        # Suffix match (e.g., .example.com matches sub.example.com)
+        if host.endswith('.' + pattern):
+            return True
+
+        # Also check if pattern matches with a leading dot
+        if host.endswith(pattern):
+            # Make sure we're matching a domain boundary
+            prefix_len = len(host) - len(pattern)
+            if prefix_len == 0 or host[prefix_len - 1] == '.':
+                return True
+
+    return False
 
 JSON_SCHEMA_VALIDATION_KEYWORDS = {
     'multipleOf', 'maximum', 'exclusiveMaximum',
@@ -231,7 +319,14 @@ conf = {{{packageName}}}.Configuration(
         {{/asyncio}}
 
         self.proxy: Optional[str] = None
-        """Proxy URL
+        """Proxy URL. If not set, will be read from environment variables
+           (HTTPS_PROXY, HTTP_PROXY, ALL_PROXY) when making requests.
+        """
+        self.no_proxy: Optional[List[str]] = None
+        """List of hosts that should bypass the proxy. If not set, will be
+           read from NO_PROXY environment variable when making requests.
+           Supports exact matches and suffix matches (e.g., '.example.com'
+           matches 'sub.example.com'). Use '*' to bypass all proxies.
         """
         self.proxy_headers = None
         """Proxy headers
@@ -590,3 +685,30 @@ conf = {{{packageName}}}.Configuration(
         """Fix base path."""
         self._base_path = value
         self.server_index = None
+
+    def get_proxy_for_url(self, url: str) -> Optional[str]:
+        """Get the proxy URL to use for the given target URL.
+
+        This method considers both the explicit proxy configuration and
+        environment variables (HTTPS_PROXY, HTTP_PROXY, NO_PROXY).
+
+        :param url: The target URL.
+        :return: The proxy URL to use, or None if no proxy should be used.
+        """
+        # Get proxy URL (explicit config takes precedence)
+        proxy_url = self.proxy
+        if proxy_url is None:
+            proxy_url = _get_proxy_from_environment(url)
+
+        if not proxy_url:
+            return None
+
+        # Check no_proxy list
+        no_proxy_list = self.no_proxy
+        if no_proxy_list is None:
+            no_proxy_list = _get_no_proxy_from_environment()
+
+        if _should_bypass_proxy(url, no_proxy_list):
+            return None
+
+        return proxy_url

--- a/sdk/templates/python/rest.mustache
+++ b/sdk/templates/python/rest.mustache
@@ -55,51 +55,76 @@ class RESTClientObject:
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
         # Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501
 
+        self.configuration = configuration
+
         # cert_reqs
         if configuration.verify_ssl:
             cert_reqs = ssl.CERT_REQUIRED
         else:
             cert_reqs = ssl.CERT_NONE
 
-        pool_args = {
+        self.pool_args = {
             "cert_reqs": cert_reqs,
             "ca_certs": configuration.ssl_ca_cert,
             "cert_file": configuration.cert_file,
             "key_file": configuration.key_file,
         }
         if configuration.assert_hostname is not None:
-            pool_args['assert_hostname'] = (
+            self.pool_args['assert_hostname'] = (
                 configuration.assert_hostname
             )
 
         if configuration.retries is not None:
-            pool_args['retries'] = configuration.retries
+            self.pool_args['retries'] = configuration.retries
 
         if configuration.tls_server_name:
-            pool_args['server_hostname'] = configuration.tls_server_name
+            self.pool_args['server_hostname'] = configuration.tls_server_name
 
 
         if configuration.socket_options is not None:
-            pool_args['socket_options'] = configuration.socket_options
+            self.pool_args['socket_options'] = configuration.socket_options
 
         if configuration.connection_pool_maxsize is not None:
-            pool_args['maxsize'] = configuration.connection_pool_maxsize
+            self.pool_args['maxsize'] = configuration.connection_pool_maxsize
 
-        # https pool manager
-        self.pool_manager: urllib3.PoolManager
+        # Cache for pool managers (keyed by proxy URL, None for no proxy)
+        self._pool_managers: dict = {}
 
-        if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+    def _get_pool_manager(self, url: str) -> urllib3.PoolManager:
+        """Get the appropriate pool manager for the given URL.
+
+        This method considers proxy settings and no_proxy configuration,
+        including environment variables (HTTPS_PROXY, HTTP_PROXY, NO_PROXY).
+
+        :param url: The target URL.
+        :return: The appropriate pool manager.
+        """
+        # Get the proxy URL for this request (considers no_proxy)
+        proxy_url = self.configuration.get_proxy_for_url(url)
+
+        # Check if we already have a pool manager for this proxy
+        if proxy_url in self._pool_managers:
+            return self._pool_managers[proxy_url]
+
+        # Create a new pool manager
+        pool_args = self.pool_args.copy()
+
+        if proxy_url:
+            if is_socks_proxy_url(proxy_url):
                 from urllib3.contrib.socks import SOCKSProxyManager
-                pool_args["proxy_url"] = configuration.proxy
-                pool_args["headers"] = configuration.proxy_headers
-                self.pool_manager = SOCKSProxyManager(**pool_args)
+                pool_args["proxy_url"] = proxy_url
+                pool_args["headers"] = self.configuration.proxy_headers
+                pool_manager = SOCKSProxyManager(**pool_args)
             else:
-                pool_args["proxy_url"] = configuration.proxy
-                pool_args["proxy_headers"] = configuration.proxy_headers
-                self.pool_manager = urllib3.ProxyManager(**pool_args)
+                pool_args["proxy_url"] = proxy_url
+                pool_args["proxy_headers"] = self.configuration.proxy_headers
+                pool_manager = urllib3.ProxyManager(**pool_args)
         else:
-            self.pool_manager = urllib3.PoolManager(**pool_args)
+            pool_manager = urllib3.PoolManager(**pool_args)
+
+        # Cache the pool manager
+        self._pool_managers[proxy_url] = pool_manager
+        return pool_manager
 
     def request(
         self,
@@ -157,6 +182,10 @@ class RESTClientObject:
                 )
 
         try:
+            # Get the appropriate pool manager for this URL
+            # (considers proxy settings and no_proxy)
+            pool_manager = self._get_pool_manager(url)
+
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
 
@@ -169,7 +198,7 @@ class RESTClientObject:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body)
-                    r = self.pool_manager.request(
+                    r = pool_manager.request(
                         method,
                         url,
                         body=request_body,
@@ -178,7 +207,7 @@ class RESTClientObject:
                         preload_content=False
                     )
                 elif content_type == 'application/x-www-form-urlencoded':
-                    r = self.pool_manager.request(
+                    r = pool_manager.request(
                         method,
                         url,
                         fields=post_params,
@@ -192,7 +221,7 @@ class RESTClientObject:
                     # Content-Type which generated by urllib3 will be
                     # overwritten.
                     del headers['Content-Type']
-                    r = self.pool_manager.request(
+                    r = pool_manager.request(
                         method,
                         url,
                         fields=post_params,
@@ -205,7 +234,7 @@ class RESTClientObject:
                 # other content types than JSON when `body` argument is
                 # provided in serialized form.
                 elif isinstance(body, str) or isinstance(body, bytes):
-                    r = self.pool_manager.request(
+                    r = pool_manager.request(
                         method,
                         url,
                         body=body,
@@ -215,7 +244,7 @@ class RESTClientObject:
                     )
                 elif headers['Content-Type'] == 'text/plain' and isinstance(body, bool):
                     request_body = "true" if body else "false"
-                    r = self.pool_manager.request(
+                    r = pool_manager.request(
                         method,
                         url,
                         body=request_body,
@@ -230,7 +259,7 @@ class RESTClientObject:
                     raise ApiException(status=0, reason=msg)
             # For `GET`, `HEAD`
             else:
-                r = self.pool_manager.request(
+                r = pool_manager.request(
                     method,
                     url,
                     fields={},


### PR DESCRIPTION
PoC for #98 

## Usage example

```python
 import os
  from pulumi_esc_sdk import EscClient, default_config

  # Environment variables are automatically read:
  # - HTTPS_PROXY / https_proxy
  # - HTTP_PROXY / http_proxy
  # - NO_PROXY / no_proxy (comma-separated list of hosts)

  # Or set programmatically:
  config = default_config()
  config.proxy = "http://proxy.example.com:8080"
  config.no_proxy = ["localhost", "127.0.0.1", ".internal.company.com"]

  client = EscClient(config)

```