### PR TITLE
Fix Github release action by removing overridden permissions

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -34,8 +34,6 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Fetch secrets from ESC


### PR DESCRIPTION
The top-level permission added in https://github.com/pulumi/esc-sdk/pull/95 is needed (includes id-token: write)
but when the OIDC auth was added at the same time to this job the lower
level permission override was missed leading to this permission issue.

Closes #103 