### PR TITLE
feat(csharp): add Esc.Extensions.Configuration library

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,10 @@
   EnvironmentDefinitionSerializer), and xUnit tests
   [#118](https://github.com/pulumi/esc-sdk/pull/118)
 
+- Add `Pulumi.Esc.Extensions.Configuration` library integrating Pulumi ESC with .NET's
+  `Microsoft.Extensions.Configuration` system
+  [#128](https://github.com/pulumi/esc-sdk/pull/128)
+
 - Support proxy environment variables in Python SDK
   [#108](https://github.com/pulumi/esc-sdk/pull/108)
 

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration.Tests/EscConfigurationProviderTests.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration.Tests/EscConfigurationProviderTests.cs
@@ -1,0 +1,342 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Pulumi.Esc.Sdk.Model;
+
+namespace Pulumi.Esc.Extensions.Configuration.Tests;
+
+public class EscConfigurationProviderTests
+{
+    private static EscConfigurationOptions DefaultOptions => new()
+    {
+        Organization = "test-org",
+        Project = "test-project",
+        Environment = "test-env"
+    };
+
+    private static EscConfigurationProvider BuildProvider(
+        IEscClient client,
+        EscConfigurationOptions? options = null)
+        => new(options ?? DefaultOptions, client);
+
+    [Fact]
+    public void Load_FlatValues_PopulatesData()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?>
+            {
+                ["apiKey"] = "secret-value",
+                ["region"] = "us-east-1"
+            }));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("apiKey", out var apiKey));
+        Assert.Equal("secret-value", apiKey);
+        Assert.True(provider.TryGet("region", out var region));
+        Assert.Equal("us-east-1", region);
+    }
+
+    [Fact]
+    public void Load_NestedObjects_FlattensWithColonSeparator()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?>
+            {
+                ["database"] = new Dictionary<string, object?>
+                {
+                    ["host"] = "localhost",
+                    ["port"] = 5432
+                }
+            }));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("database:host", out var host));
+        Assert.Equal("localhost", host);
+        Assert.True(provider.TryGet("database:port", out var port));
+        Assert.Equal("5432", port);
+    }
+
+    [Fact]
+    public void Load_DeeplyNestedObjects_FlattensCorrectly()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?>
+            {
+                ["app"] = new Dictionary<string, object?>
+                {
+                    ["db"] = new Dictionary<string, object?>
+                    {
+                        ["host"] = "db.example.com"
+                    }
+                }
+            }));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("app:db:host", out var host));
+        Assert.Equal("db.example.com", host);
+    }
+
+    [Fact]
+    public void Load_ArrayValues_FlattensWithIndexKeys()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?>
+            {
+                ["hosts"] = new List<object?> { "host1", "host2", "host3" }
+            }));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("hosts:0", out var h0));
+        Assert.Equal("host1", h0);
+        Assert.True(provider.TryGet("hosts:1", out var h1));
+        Assert.Equal("host2", h1);
+        Assert.True(provider.TryGet("hosts:2", out var h2));
+        Assert.Equal("host3", h2);
+    }
+
+    [Fact]
+    public void Load_NullValue_StoresNullInData()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?>
+            {
+                ["optionalKey"] = null
+            }));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("optionalKey", out var val));
+        Assert.Null(val);
+    }
+
+    [Fact]
+    public void Load_NullValuesFromClient_SetsEmptyData()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), (Dictionary<string, object?>?)null));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.False(provider.TryGet("anything", out _));
+    }
+
+    [Fact]
+    public void Load_KeyWithColonInName_ReturnsValue()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?>
+            {
+                ["aws:region"] = "eu-west-1"
+            }));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("aws:region", out var region));
+        Assert.Equal("eu-west-1", region);
+    }
+
+    [Fact]
+    public void Load_KeysAreCaseInsensitive()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?>
+            {
+                ["ApiKey"] = "value"
+            }));
+
+        var provider = BuildProvider(client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("apikey", out var lower));
+        Assert.Equal("value", lower);
+        Assert.True(provider.TryGet("APIKEY", out var upper));
+        Assert.Equal("value", upper);
+    }
+}
+
+public class EscConfigurationReloaderTests
+{
+    private static EscConfigurationOptions DefaultOptions => new()
+    {
+        Organization = "test-org",
+        Project = "test-project",
+        Environment = "test-env"
+    };
+
+    [Fact]
+    public async Task ReloadAsync_UpdatesData()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .SetupSequence(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?> { ["key"] = "initial" }))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?> { ["key"] = "updated" }));
+
+        var provider = new EscConfigurationProvider(DefaultOptions, client.Object);
+        provider.Load();
+
+        Assert.True(provider.TryGet("key", out var before));
+        Assert.Equal("initial", before);
+
+        await provider.ReloadAsync();
+
+        Assert.True(provider.TryGet("key", out var after));
+        Assert.Equal("updated", after);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_FiresChangeToken()
+    {
+        var client = new Mock<IEscClient>();
+        client
+            .Setup(c => c.OpenEnvironmentAsync("test-org", "test-project", "test-env", default))
+            .ReturnsAsync(("session-1", null));
+        client
+            .Setup(c => c.ReadOpenEnvironmentAsync("test-org", "test-project", "test-env", "session-1", default))
+            .ReturnsAsync((new ModelEnvironment(), new Dictionary<string, object?> { ["key"] = "value" }));
+
+        var provider = new EscConfigurationProvider(DefaultOptions, client.Object);
+        provider.Load();
+
+        var token = provider.GetReloadToken();
+        var callbackFired = false;
+        token.RegisterChangeCallback(_ => callbackFired = true, null);
+
+        await provider.ReloadAsync();
+
+        Assert.True(callbackFired);
+    }
+}
+
+public class EscServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddEscConfigurationReloader_RegistersProviderAsSingleton()
+    {
+        var client = new Mock<IEscClient>();
+        var options = new EscConfigurationOptions
+        {
+            Organization = "org",
+            Project = "proj",
+            Environment = "env"
+        };
+        var provider = new EscConfigurationProvider(options, client.Object);
+
+        var mockRoot = new Mock<IConfigurationRoot>();
+        mockRoot.Setup(r => r.Providers).Returns(new IConfigurationProvider[] { provider });
+
+        var services = new ServiceCollection();
+        services.AddEscConfigurationReloader(mockRoot.Object);
+        var sp = services.BuildServiceProvider();
+
+        var reloader = sp.GetService<IEscConfigurationReloader>();
+        Assert.NotNull(reloader);
+        Assert.Same(provider, reloader);
+    }
+}
+
+public class EscConfigurationSourceTests
+{
+    [Fact]
+    public void Build_ReturnsEscConfigurationProvider()
+    {
+        var options = new EscConfigurationOptions
+        {
+            Organization = "org",
+            Project = "proj",
+            Environment = "env",
+            AccessToken = "fake-token"
+        };
+        var source = new EscConfigurationSource(options);
+        var builder = new ConfigurationBuilder();
+
+        var provider = source.Build(builder);
+
+        Assert.IsType<EscConfigurationProvider>(provider);
+    }
+}
+
+public class EscConfigurationBuilderExtensionsTests
+{
+    [Fact]
+    public void AddEscConfiguration_WithNamedParams_AddsSingleSource()
+    {
+        var builder = new ConfigurationBuilder();
+
+        builder.AddEscConfiguration("org", "proj", "env", accessToken: "tok");
+
+        Assert.Single(builder.Sources);
+        Assert.IsType<EscConfigurationSource>(builder.Sources[0]);
+    }
+
+    [Fact]
+    public void AddEscConfiguration_WithOptions_AddsSingleSource()
+    {
+        var builder = new ConfigurationBuilder();
+        var options = new EscConfigurationOptions
+        {
+            Organization = "org",
+            Project = "proj",
+            Environment = "env"
+        };
+
+        builder.AddEscConfiguration(options);
+
+        Assert.Single(builder.Sources);
+        Assert.IsType<EscConfigurationSource>(builder.Sources[0]);
+    }
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration.Tests/EscConfigurationProviderTests.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration.Tests/EscConfigurationProviderTests.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration.Tests/Pulumi.Esc.Extensions.Configuration.Tests.csproj
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration.Tests/Pulumi.Esc.Extensions.Configuration.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Pulumi.Esc.Extensions.Configuration/Pulumi.Esc.Extensions.Configuration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/AssemblyInfo.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Pulumi.Esc.Extensions.Configuration.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/AssemblyInfo.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/AssemblyInfo.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Pulumi.Esc.Extensions.Configuration.Tests")]

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscClientAdapter.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscClientAdapter.cs
@@ -1,0 +1,28 @@
+using Pulumi.Esc.Sdk;
+using Pulumi.Esc.Sdk.Model;
+
+namespace Pulumi.Esc.Extensions.Configuration;
+
+internal sealed class EscClientAdapter : IEscClient
+{
+    private readonly EscClient _client;
+
+    public EscClientAdapter(EscClient client) => _client = client;
+
+    public Task<(string Id, List<EnvironmentDiagnostic>? Diagnostics)> OpenEnvironmentAsync(
+        string orgName,
+        string projectName,
+        string envName,
+        CancellationToken cancellationToken = default)
+        => _client.OpenEnvironmentAsync(orgName, projectName, envName, cancellationToken);
+
+    public Task<(ModelEnvironment Environment, Dictionary<string, object?>? Values)> ReadOpenEnvironmentAsync(
+        string orgName,
+        string projectName,
+        string envName,
+        string openSessionId,
+        CancellationToken cancellationToken = default)
+        => _client.ReadOpenEnvironmentAsync(orgName, projectName, envName, openSessionId, cancellationToken);
+
+    public void Dispose() => _client.Dispose();
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscClientAdapter.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscClientAdapter.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using Pulumi.Esc.Sdk;
 using Pulumi.Esc.Sdk.Model;
 

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationBuilderExtensions.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationBuilderExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Pulumi.Esc.Extensions.Configuration;
+
+public static class EscConfigurationBuilderExtensions
+{
+    public static IConfigurationBuilder AddEscConfiguration(
+        this IConfigurationBuilder builder,
+        string organization,
+        string project,
+        string environment,
+        string? accessToken = null)
+    {
+        return builder.Add(new EscConfigurationSource(new EscConfigurationOptions
+        {
+            Organization = organization,
+            Project = project,
+            Environment = environment,
+            AccessToken = accessToken
+        }));
+    }
+
+    public static IConfigurationBuilder AddEscConfiguration(
+        this IConfigurationBuilder builder,
+        EscConfigurationOptions options)
+    {
+        return builder.Add(new EscConfigurationSource(options));
+    }
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationBuilderExtensions.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationBuilderExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using Microsoft.Extensions.Configuration;
 
 namespace Pulumi.Esc.Extensions.Configuration;

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationOptions.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationOptions.cs
@@ -1,0 +1,9 @@
+namespace Pulumi.Esc.Extensions.Configuration;
+
+public class EscConfigurationOptions
+{
+    public required string Organization { get; set; }
+    public required string Project { get; set; }
+    public required string Environment { get; set; }
+    public string? AccessToken { get; set; }
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationOptions.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationOptions.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 namespace Pulumi.Esc.Extensions.Configuration;
 
 public class EscConfigurationOptions

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationProvider.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationProvider.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using Microsoft.Extensions.Configuration;
 
 namespace Pulumi.Esc.Extensions.Configuration;

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationProvider.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationProvider.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Pulumi.Esc.Extensions.Configuration;
+
+public class EscConfigurationProvider : ConfigurationProvider, IEscConfigurationReloader, IDisposable
+{
+    private readonly EscConfigurationOptions _options;
+    private readonly IEscClient _client;
+
+    internal EscConfigurationProvider(EscConfigurationOptions options, IEscClient client)
+    {
+        _options = options;
+        _client = client;
+    }
+
+    public override void Load() => LoadAsync().GetAwaiter().GetResult();
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await LoadAsync(cancellationToken);
+        OnReload();
+    }
+
+    private async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var (sessionId, _) = await _client.OpenEnvironmentAsync(
+            _options.Organization, _options.Project, _options.Environment, cancellationToken);
+
+        var (_, values) = await _client.ReadOpenEnvironmentAsync(
+            _options.Organization, _options.Project, _options.Environment, sessionId, cancellationToken);
+
+        var data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        if (values is not null)
+        {
+            foreach (var kvp in values)
+                Flatten(kvp.Key, kvp.Value, data);
+        }
+
+        Data = data;
+    }
+
+    private static void Flatten(string prefix, object? value, Dictionary<string, string?> result)
+    {
+        switch (value)
+        {
+            case Dictionary<string, object?> dict:
+                foreach (var kvp in dict)
+                    Flatten($"{prefix}:{kvp.Key}", kvp.Value, result);
+                break;
+            case List<object?> list:
+                for (var i = 0; i < list.Count; i++)
+                    Flatten($"{prefix}:{i}", list[i], result);
+                break;
+            default:
+                result[prefix] = value?.ToString();
+                break;
+        }
+    }
+
+    public void Dispose() => _client.Dispose();
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationSource.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationSource.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using Microsoft.Extensions.Configuration;
 using Pulumi.Esc.Sdk;
 

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationSource.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscConfigurationSource.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Configuration;
+using Pulumi.Esc.Sdk;
+
+namespace Pulumi.Esc.Extensions.Configuration;
+
+public class EscConfigurationSource : IConfigurationSource
+{
+    private readonly EscConfigurationOptions _options;
+
+    public IEscConfigurationReloader? Reloader { get; private set; }
+
+    public EscConfigurationSource(EscConfigurationOptions options)
+    {
+        _options = options;
+    }
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        var escClient = _options.AccessToken is not null
+            ? EscClient.Create(_options.AccessToken)
+            : EscClient.CreateDefault();
+        var provider = new EscConfigurationProvider(_options, new EscClientAdapter(escClient));
+        Reloader = provider;
+        return provider;
+    }
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscServiceCollectionExtensions.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Pulumi.Esc.Extensions.Configuration;
+
+public static class EscServiceCollectionExtensions
+{
+    public static IServiceCollection AddEscConfigurationReloader(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var root = (IConfigurationRoot)configuration;
+        var provider = root.Providers.OfType<EscConfigurationProvider>().First();
+        return services.AddSingleton<IEscConfigurationReloader>(provider);
+    }
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscServiceCollectionExtensions.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/EscServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscClient.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscClient.cs
@@ -1,0 +1,19 @@
+using Pulumi.Esc.Sdk.Model;
+
+namespace Pulumi.Esc.Extensions.Configuration;
+
+internal interface IEscClient : IDisposable
+{
+    Task<(string Id, List<EnvironmentDiagnostic>? Diagnostics)> OpenEnvironmentAsync(
+        string orgName,
+        string projectName,
+        string envName,
+        CancellationToken cancellationToken = default);
+
+    Task<(ModelEnvironment Environment, Dictionary<string, object?>? Values)> ReadOpenEnvironmentAsync(
+        string orgName,
+        string projectName,
+        string envName,
+        string openSessionId,
+        CancellationToken cancellationToken = default);
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscClient.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscClient.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 using Pulumi.Esc.Sdk.Model;
 
 namespace Pulumi.Esc.Extensions.Configuration;

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscConfigurationReloader.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscConfigurationReloader.cs
@@ -1,0 +1,6 @@
+namespace Pulumi.Esc.Extensions.Configuration;
+
+public interface IEscConfigurationReloader
+{
+    Task ReloadAsync(CancellationToken cancellationToken = default);
+}

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscConfigurationReloader.cs
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/IEscConfigurationReloader.cs
@@ -1,3 +1,5 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
 namespace Pulumi.Esc.Extensions.Configuration;
 
 public interface IEscConfigurationReloader

--- a/sdk/csharp/Pulumi.Esc.Extensions.Configuration/Pulumi.Esc.Extensions.Configuration.csproj
+++ b/sdk/csharp/Pulumi.Esc.Extensions.Configuration/Pulumi.Esc.Extensions.Configuration.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Pulumi.Esc.Sdk" Version="0.13.1" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/go/api_esc_test.go
+++ b/sdk/go/api_esc_test.go
@@ -67,11 +67,20 @@ func Test_EscClient(t *testing.T) {
 			require.Nil(t, err)
 		})
 
-		envs, err := apiClient.ListEnvironments(auth, orgName, nil)
-		require.Nil(t, err)
+		var allEnvs []OrgEnvironment
+		var token *string
+		for {
+			page, err := apiClient.ListEnvironments(auth, orgName, token)
+			require.Nil(t, err)
+			allEnvs = append(allEnvs, page.Environments...)
+			token = page.NextToken
+			if token == nil || *token == "" {
+				break
+			}
+		}
 
-		requireFindEnvironment(t, envs, PROJECT_NAME, envName)
-		requireFindEnvironment(t, envs, cloneProject, cloneName)
+		requireFindEnvironment(t, allEnvs, PROJECT_NAME, envName)
+		requireFindEnvironment(t, allEnvs, cloneProject, cloneName)
 
 		_, values, err := apiClient.OpenAndReadEnvironment(auth, orgName, PROJECT_NAME, envName)
 		require.Nil(t, err)
@@ -253,9 +262,9 @@ func assertEnvDef(t *testing.T, env *EnvironmentDefinition, baseEnvName string) 
 	require.Equal(t, "${foo}", envVariables["FOO"])
 }
 
-func requireFindEnvironment(t *testing.T, envs *OrgEnvironments, findProject, findName string) {
+func requireFindEnvironment(t *testing.T, envs []OrgEnvironment, findProject, findName string) {
 	found := false
-	for _, env := range envs.Environments {
+	for _, env := range envs {
 		if env.Project == findProject && env.Name == findName {
 			found = true
 		}

--- a/sdk/python/test/test_esc_api.py
+++ b/sdk/python/test/test_esc_api.py
@@ -38,9 +38,16 @@ class TestEscApi(unittest.TestCase):
         cloneName = f"{self.envName}-clone"
         self.client.clone_environment(self.orgName, PROJECT_NAME, self.envName, cloneProject, cloneName)
 
-        envs = self.client.list_environments(self.orgName)
-        self.assertFindEnv(envs, PROJECT_NAME, self.envName)
-        self.assertFindEnv(envs, cloneProject, cloneName)
+        all_envs = []
+        token = None
+        while True:
+            page = self.client.list_environments(self.orgName, token)
+            all_envs.extend(page.environments)
+            token = page.next_token
+            if not token:
+                break
+        self.assertFindEnv(all_envs, PROJECT_NAME, self.envName)
+        self.assertFindEnv(all_envs, cloneProject, cloneName)
 
         _, _, yaml = self.client.open_and_read_environment(self.orgName, PROJECT_NAME, self.envName)
         self.assertEqual(yaml, "{}\n")
@@ -176,9 +183,8 @@ values:
         self.assertEqual(env.values.environment_variables["FOO"], "${foo}")
 
     def assertFindEnv(self, envs, findProject, findName):
-        self.assertIsNotNone(envs)
-        self.assertGreater(len(envs.environments), 0)
-        for env in envs.environments:
+        self.assertGreater(len(envs), 0)
+        for env in envs:
             if env.project == findProject and env.name == findName:
                 return
 

--- a/sdk/typescript/test/client.spec.ts
+++ b/sdk/typescript/test/client.spec.ts
@@ -49,10 +49,16 @@ describe("ESC", async () => {
         const cloneName = `${name}-clone`;
         await assert.doesNotReject(client.cloneEnvironment(PULUMI_ORG, PROJECT_NAME, name, cloneProject, cloneName));
 
-        const resp = await client.listEnvironments(PULUMI_ORG);
-        assert.notEqual(resp, undefined);
-        assert(resp!.environments!.some((e) => e.project == PROJECT_NAME && e.name === name));
-        assert(resp!.environments!.some((e) => e.project == cloneProject && e.name === cloneName));
+        let allEnvs: esc.OrgEnvironment[] = [];
+        let token: string | undefined = undefined;
+        do {
+            const page = await client.listEnvironments(PULUMI_ORG, token);
+            assert.notEqual(page, undefined);
+            allEnvs = allEnvs.concat(page!.environments ?? []);
+            token = page?.nextToken;
+        } while (token !== undefined && token !== "");
+        assert(allEnvs.some((e) => e.project == PROJECT_NAME && e.name === name));
+        assert(allEnvs.some((e) => e.project == cloneProject && e.name === cloneName));
 
         let openEmptyEnv = await client.openAndReadEnvironment(PULUMI_ORG, PROJECT_NAME, name);
         assert.deepEqual(openEmptyEnv?.environment, {});


### PR DESCRIPTION
## Summary

Adds a new `Pulumi.Esc.Extensions.Configuration` library that integrates Pulumi ESC with the standard .NET configuration system (`Microsoft.Extensions.Configuration`).

Also fixes a pre-existing flaky integration test across the Go, TypeScript, and Python SDKs where `listEnvironments` was called without pagination, causing tests to fail when the org's environment list exceeded a single page.

## Changes

### C# — Esc.Extensions.Configuration

- **`EscConfigurationProvider`** — loads ESC environment values into the .NET configuration system, with support for nested key flattening (using `:` as separator) and list indexing
- **`EscConfigurationSource`** — `IConfigurationSource` implementation to wire the provider into the configuration pipeline
- **`EscConfigurationBuilderExtensions`** — convenience extension method on `IConfigurationBuilder` (`AddPulumiEsc`)
- **`EscServiceCollectionExtensions`** — DI extension to register `IEscConfigurationReloader` for on-demand reloads
- **`EscConfigurationOptions`** — options record holding organization, project, and environment names
- **`IEscClient` / `EscClientAdapter`** — thin adapter over the existing `EscClient` to enable unit testing
- **`IEscConfigurationReloader`** — interface for triggering configuration reloads at runtime
- **Test project** — unit tests for the configuration provider covering load, reload, nested key flattening, and list handling

### Integration test fixes (Go, TypeScript, Python)

- Paginate through all pages of `listEnvironments` before asserting newly-created environments are present, fixing a flaky failure when the org has many environments

## Testing

```
dotnet test sdk/csharp/Pulumi.Esc.Extensions.Configuration.Tests
```

Fixes: #19