### PR TITLE
docs: fix occured typo in workspace error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+### Bug Fixes
+
+- Fix typo (occured -> occurred) in Python SDK workspace error messages
+  [#131](https://github.com/pulumi/esc-sdk/pull/131)
+
 ## 0.13.0
 
 ### Improvements

--- a/sdk/python/pulumi_esc_sdk/workspace.py
+++ b/sdk/python/pulumi_esc_sdk/workspace.py
@@ -55,7 +55,7 @@ def get_esc_current_account_name() -> Optional[str]:
     except KeyError:
         return None
     except Exception as e:
-        print(f"An unexpected error occured: {e}")
+        print(f"An unexpected error occurred: {e}")
         return None
 
 def get_stored_credentials() -> Credentials:
@@ -71,9 +71,9 @@ def get_stored_credentials() -> Credentials:
     except FileNotFoundError:
         return None
     except Exception as e:
-        print(f"An unexpected error occured: {e}")
+        print(f"An unexpected error occurred: {e}")
         return None
-    
+
 def get_current_account() -> tuple[Account, str]:
     """
     Gets current account values from credentials file.


### PR DESCRIPTION
Fixes "An unexpected error occured" -> "occurred" in two print statements in `sdk/python/pulumi_esc_sdk/workspace.py`.