### PR TITLE
test: use GetEnvironment for existence checks (fix list pagination flake)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,7 +12,7 @@
 - Fix Python default_client return type annotation
   [#109](https://github.com/pulumi/esc-sdk/pull/109)
 
-- Paginate `listEnvironments` in Go and TypeScript integration tests to avoid flakes when the shared test org exceeds one page
+- Replace pagination-dependent `listEnvironments` existence checks with direct `getEnvironment` calls in Go, TypeScript, Python, and C# integration tests to remove a flake when the shared test org grows past one page
   [#134](https://github.com/pulumi/esc-sdk/pull/134)
 
 ### Breaking changes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,4 +12,7 @@
 - Fix Python default_client return type annotation
   [#109](https://github.com/pulumi/esc-sdk/pull/109)
 
+- Paginate `listEnvironments` in Go and TypeScript integration tests to avoid flakes when the shared test org exceeds one page
+  [#134](https://github.com/pulumi/esc-sdk/pull/134)
+
 ### Breaking changes

--- a/sdk/csharp/Pulumi.Esc.Sdk.Tests/EscApiTests.cs
+++ b/sdk/csharp/Pulumi.Esc.Sdk.Tests/EscApiTests.cs
@@ -63,10 +63,9 @@ namespace Pulumi.Esc.Sdk.Tests
                 await _client.CreateEnvironmentAsync(_orgName, ProjectName, envName);
                 await _client.CloneEnvironmentAsync(_orgName, ProjectName, envName, CloneProjectName, cloneName);
 
-                // -- List environments --
-                var envs = await ListAllEnvironmentsAsync();
-                AssertFindEnvironment(envs, ProjectName, envName);
-                AssertFindEnvironment(envs, CloneProjectName, cloneName);
+                // -- Verify created and cloned environments are queryable --
+                await _client.GetEnvironmentAsync(_orgName, ProjectName, envName);
+                await _client.GetEnvironmentAsync(_orgName, CloneProjectName, cloneName);
 
                 // -- Open and read (empty env should have no values) --
                 var (_, emptyValues) = await _client.OpenAndReadEnvironmentAsync(_orgName, ProjectName, envName);
@@ -250,27 +249,6 @@ values:
             {
                 // Ignore — cleanup is best-effort
             }
-        }
-
-        private static void AssertFindEnvironment(IEnumerable<OrgEnvironment> envs, string project, string name)
-        {
-            Assert.Contains(envs, e => e.Project == project && e.Name == name);
-        }
-
-        private async Task<List<OrgEnvironment>> ListAllEnvironmentsAsync()
-        {
-            var all = new List<OrgEnvironment>();
-            string? continuationToken = null;
-            do
-            {
-                var envs = await _client.ListEnvironmentsAsync(_orgName, continuationToken);
-                if (envs.Environments != null)
-                {
-                    all.AddRange(envs.Environments);
-                }
-                continuationToken = envs.NextToken;
-            } while (!string.IsNullOrEmpty(continuationToken));
-            return all;
         }
 
         private async Task RemoveAllCSharpTestEnvsAsync()

--- a/sdk/csharp/Pulumi.Esc.Sdk.Tests/EscApiTests.cs
+++ b/sdk/csharp/Pulumi.Esc.Sdk.Tests/EscApiTests.cs
@@ -64,7 +64,7 @@ namespace Pulumi.Esc.Sdk.Tests
                 await _client.CloneEnvironmentAsync(_orgName, ProjectName, envName, CloneProjectName, cloneName);
 
                 // -- List environments --
-                var envs = await _client.ListEnvironmentsAsync(_orgName);
+                var envs = await ListAllEnvironmentsAsync();
                 AssertFindEnvironment(envs, ProjectName, envName);
                 AssertFindEnvironment(envs, CloneProjectName, cloneName);
 
@@ -252,9 +252,25 @@ values:
             }
         }
 
-        private static void AssertFindEnvironment(OrgEnvironments envs, string project, string name)
+        private static void AssertFindEnvironment(IEnumerable<OrgEnvironment> envs, string project, string name)
         {
-            Assert.Contains(envs.Environments!, e => e.Project == project && e.Name == name);
+            Assert.Contains(envs, e => e.Project == project && e.Name == name);
+        }
+
+        private async Task<List<OrgEnvironment>> ListAllEnvironmentsAsync()
+        {
+            var all = new List<OrgEnvironment>();
+            string? continuationToken = null;
+            do
+            {
+                var envs = await _client.ListEnvironmentsAsync(_orgName, continuationToken);
+                if (envs.Environments != null)
+                {
+                    all.AddRange(envs.Environments);
+                }
+                continuationToken = envs.NextToken;
+            } while (!string.IsNullOrEmpty(continuationToken));
+            return all;
         }
 
         private async Task RemoveAllCSharpTestEnvsAsync()

--- a/sdk/go/api_esc_test.go
+++ b/sdk/go/api_esc_test.go
@@ -67,8 +67,7 @@ func Test_EscClient(t *testing.T) {
 			require.Nil(t, err)
 		})
 
-		envs, err := apiClient.ListEnvironments(auth, orgName, nil)
-		require.Nil(t, err)
+		envs := listAllEnvironments(t, apiClient, auth, orgName)
 
 		requireFindEnvironment(t, envs, PROJECT_NAME, envName)
 		requireFindEnvironment(t, envs, cloneProject, cloneName)
@@ -253,9 +252,26 @@ func assertEnvDef(t *testing.T, env *EnvironmentDefinition, baseEnvName string) 
 	require.Equal(t, "${foo}", envVariables["FOO"])
 }
 
-func requireFindEnvironment(t *testing.T, envs *OrgEnvironments, findProject, findName string) {
+func listAllEnvironments(t *testing.T, apiClient *EscClient, auth context.Context, orgName string) []OrgEnvironment {
+	var all []OrgEnvironment
+	var continuationToken *string
+	for {
+		envs, err := apiClient.ListEnvironments(auth, orgName, continuationToken)
+		require.Nil(t, err)
+
+		all = append(all, envs.Environments...)
+
+		continuationToken = envs.NextToken
+		if continuationToken == nil || *continuationToken == "" {
+			break
+		}
+	}
+	return all
+}
+
+func requireFindEnvironment(t *testing.T, envs []OrgEnvironment, findProject, findName string) {
 	found := false
-	for _, env := range envs.Environments {
+	for _, env := range envs {
 		if env.Project == findProject && env.Name == findName {
 			found = true
 		}

--- a/sdk/go/api_esc_test.go
+++ b/sdk/go/api_esc_test.go
@@ -67,10 +67,10 @@ func Test_EscClient(t *testing.T) {
 			require.Nil(t, err)
 		})
 
-		envs := listAllEnvironments(t, apiClient, auth, orgName)
-
-		requireFindEnvironment(t, envs, PROJECT_NAME, envName)
-		requireFindEnvironment(t, envs, cloneProject, cloneName)
+		_, _, err = apiClient.GetEnvironment(auth, orgName, PROJECT_NAME, envName)
+		require.Nil(t, err, "created env should exist")
+		_, _, err = apiClient.GetEnvironment(auth, orgName, cloneProject, cloneName)
+		require.Nil(t, err, "cloned env should exist")
 
 		_, values, err := apiClient.OpenAndReadEnvironment(auth, orgName, PROJECT_NAME, envName)
 		require.Nil(t, err)
@@ -250,34 +250,6 @@ func assertEnvDef(t *testing.T, env *EnvironmentDefinition, baseEnvName string) 
 	require.NotNil(t, env.Values.EnvironmentVariables)
 	envVariables := *env.Values.EnvironmentVariables
 	require.Equal(t, "${foo}", envVariables["FOO"])
-}
-
-func listAllEnvironments(t *testing.T, apiClient *EscClient, auth context.Context, orgName string) []OrgEnvironment {
-	var all []OrgEnvironment
-	var continuationToken *string
-	for {
-		envs, err := apiClient.ListEnvironments(auth, orgName, continuationToken)
-		require.Nil(t, err)
-
-		all = append(all, envs.Environments...)
-
-		continuationToken = envs.NextToken
-		if continuationToken == nil || *continuationToken == "" {
-			break
-		}
-	}
-	return all
-}
-
-func requireFindEnvironment(t *testing.T, envs []OrgEnvironment, findProject, findName string) {
-	found := false
-	for _, env := range envs {
-		if env.Project == findProject && env.Name == findName {
-			found = true
-		}
-	}
-
-	require.True(t, found)
 }
 
 func removeAllGoTestEnvs(t *testing.T, apiClient *EscClient, auth context.Context, orgName string) {

--- a/sdk/python/test/test_esc_api.py
+++ b/sdk/python/test/test_esc_api.py
@@ -38,7 +38,7 @@ class TestEscApi(unittest.TestCase):
         cloneName = f"{self.envName}-clone"
         self.client.clone_environment(self.orgName, PROJECT_NAME, self.envName, cloneProject, cloneName)
 
-        envs = self.client.list_environments(self.orgName)
+        envs = self.list_all_environments()
         self.assertFindEnv(envs, PROJECT_NAME, self.envName)
         self.assertFindEnv(envs, cloneProject, cloneName)
 
@@ -177,12 +177,24 @@ values:
 
     def assertFindEnv(self, envs, findProject, findName):
         self.assertIsNotNone(envs)
-        self.assertGreater(len(envs.environments), 0)
-        for env in envs.environments:
+        self.assertGreater(len(envs), 0)
+        for env in envs:
             if env.project == findProject and env.name == findName:
                 return
 
         self.fail(f"Environment {findProject}/{findName} not found")
+
+    def list_all_environments(self):
+        all_envs = []
+        continuationToken = None
+        while True:
+            envs = self.client.list_environments(self.orgName, continuationToken)
+            if envs.environments:
+                all_envs.extend(envs.environments)
+            continuationToken = envs.next_token
+            if continuationToken is None or continuationToken == "":
+                break
+        return all_envs
 
     def remove_all_python_test_envs(self) -> None:
         continuationToken = None

--- a/sdk/python/test/test_esc_api.py
+++ b/sdk/python/test/test_esc_api.py
@@ -38,9 +38,8 @@ class TestEscApi(unittest.TestCase):
         cloneName = f"{self.envName}-clone"
         self.client.clone_environment(self.orgName, PROJECT_NAME, self.envName, cloneProject, cloneName)
 
-        envs = self.list_all_environments()
-        self.assertFindEnv(envs, PROJECT_NAME, self.envName)
-        self.assertFindEnv(envs, cloneProject, cloneName)
+        self.client.get_environment(self.orgName, PROJECT_NAME, self.envName)
+        self.client.get_environment(self.orgName, cloneProject, cloneName)
 
         _, _, yaml = self.client.open_and_read_environment(self.orgName, PROJECT_NAME, self.envName)
         self.assertEqual(yaml, "{}\n")
@@ -174,27 +173,6 @@ values:
         self.assertEqual(env.values.pulumi_config["foo"], "${foo}")
         self.assertIsNotNone(env.values.environment_variables)
         self.assertEqual(env.values.environment_variables["FOO"], "${foo}")
-
-    def assertFindEnv(self, envs, findProject, findName):
-        self.assertIsNotNone(envs)
-        self.assertGreater(len(envs), 0)
-        for env in envs:
-            if env.project == findProject and env.name == findName:
-                return
-
-        self.fail(f"Environment {findProject}/{findName} not found")
-
-    def list_all_environments(self):
-        all_envs = []
-        continuationToken = None
-        while True:
-            envs = self.client.list_environments(self.orgName, continuationToken)
-            if envs.environments:
-                all_envs.extend(envs.environments)
-            continuationToken = envs.next_token
-            if continuationToken is None or continuationToken == "":
-                break
-        return all_envs
 
     def remove_all_python_test_envs(self) -> None:
         continuationToken = None

--- a/sdk/typescript/test/client.spec.ts
+++ b/sdk/typescript/test/client.spec.ts
@@ -49,9 +49,14 @@ describe("ESC", async () => {
         const cloneName = `${name}-clone`;
         await assert.doesNotReject(client.cloneEnvironment(PULUMI_ORG, PROJECT_NAME, name, cloneProject, cloneName));
 
-        const allEnvs = await listAllEnvironments(client, PULUMI_ORG);
-        assert(allEnvs.some((e) => e.project == PROJECT_NAME && e.name === name));
-        assert(allEnvs.some((e) => e.project == cloneProject && e.name === cloneName));
+        await assert.doesNotReject(
+            client.getEnvironment(PULUMI_ORG, PROJECT_NAME, name),
+            "created env should exist",
+        );
+        await assert.doesNotReject(
+            client.getEnvironment(PULUMI_ORG, cloneProject, cloneName),
+            "cloned env should exist",
+        );
 
         let openEmptyEnv = await client.openAndReadEnvironment(PULUMI_ORG, PROJECT_NAME, name);
         assert.deepEqual(openEmptyEnv?.environment, {});
@@ -214,20 +219,6 @@ function assertEnvDef(env: esc.EnvironmentDefinitionResponse, baseEnvName: strin
     assert.deepEqual(env.definition?.values?.my_array, [1, 2, 3]);
     assert.equal(env.definition?.values?.pulumiConfig?.foo, "${foo}");
     assert.equal(env.definition?.values?.environmentVariables?.FOO, "${foo}");
-}
-
-async function listAllEnvironments(client: esc.EscApi, orgName: string): Promise<esc.OrgEnvironment[]> {
-    const all: esc.OrgEnvironment[] = [];
-    let continuationToken: string | undefined = undefined;
-    do {
-        const orgs: esc.OrgEnvironments | undefined = await client.listEnvironments(orgName, continuationToken);
-        assert.notEqual(orgs, undefined);
-        if (orgs?.environments) {
-            all.push(...orgs.environments);
-        }
-        continuationToken = orgs?.nextToken;
-    } while (continuationToken !== undefined && continuationToken !== "");
-    return all;
 }
 
 async function removeAllTestEnvs(client: esc.EscApi, orgName: string): Promise<any> {

--- a/sdk/typescript/test/client.spec.ts
+++ b/sdk/typescript/test/client.spec.ts
@@ -49,10 +49,9 @@ describe("ESC", async () => {
         const cloneName = `${name}-clone`;
         await assert.doesNotReject(client.cloneEnvironment(PULUMI_ORG, PROJECT_NAME, name, cloneProject, cloneName));
 
-        const resp = await client.listEnvironments(PULUMI_ORG);
-        assert.notEqual(resp, undefined);
-        assert(resp!.environments!.some((e) => e.project == PROJECT_NAME && e.name === name));
-        assert(resp!.environments!.some((e) => e.project == cloneProject && e.name === cloneName));
+        const allEnvs = await listAllEnvironments(client, PULUMI_ORG);
+        assert(allEnvs.some((e) => e.project == PROJECT_NAME && e.name === name));
+        assert(allEnvs.some((e) => e.project == cloneProject && e.name === cloneName));
 
         let openEmptyEnv = await client.openAndReadEnvironment(PULUMI_ORG, PROJECT_NAME, name);
         assert.deepEqual(openEmptyEnv?.environment, {});
@@ -215,6 +214,20 @@ function assertEnvDef(env: esc.EnvironmentDefinitionResponse, baseEnvName: strin
     assert.deepEqual(env.definition?.values?.my_array, [1, 2, 3]);
     assert.equal(env.definition?.values?.pulumiConfig?.foo, "${foo}");
     assert.equal(env.definition?.values?.environmentVariables?.FOO, "${foo}");
+}
+
+async function listAllEnvironments(client: esc.EscApi, orgName: string): Promise<esc.OrgEnvironment[]> {
+    const all: esc.OrgEnvironment[] = [];
+    let continuationToken: string | undefined = undefined;
+    do {
+        const orgs: esc.OrgEnvironments | undefined = await client.listEnvironments(orgName, continuationToken);
+        assert.notEqual(orgs, undefined);
+        if (orgs?.environments) {
+            all.push(...orgs.environments);
+        }
+        continuationToken = orgs?.nextToken;
+    } while (continuationToken !== undefined && continuationToken !== "");
+    return all;
 }
 
 async function removeAllTestEnvs(client: esc.EscApi, orgName: string): Promise<any> {


### PR DESCRIPTION
## Summary

`Test_EscClient/should_create,_clone,_list,_update,_get,_decrypt,_open_and_delete_an_environment` (and the equivalent Python/TS/C# tests) flake on PRs because they call `listEnvironments` once and assert the freshly-created env is in the first page. When the shared `pulumi` test org accumulates enough environments across concurrent PR runs, the new env lands on a later page and the assertion fails.

The assertion's real intent is "the env was created and is queryable," not "the list endpoint returns the env on page 1." Switching to `getEnvironment` answers that question in one request and removes any dependency on org size / pagination ordering.

## Changes

- Go (`sdk/go/api_esc_test.go`): replace the `requireFindEnvironment` block with two `GetEnvironment` calls and `require.Nil(t, err, "...")`. Removed the now-unused helper.
- TypeScript (`sdk/typescript/test/client.spec.ts`): replace the `.some(...)` assertions with `assert.doesNotReject(client.getEnvironment(...))`.
- Python (`sdk/python/test/test_esc_api.py`): replace `assertFindEnv` with `self.client.get_environment(...)` (raises on 404). Removed the now-unused helper.
- C# (`Pulumi.Esc.Sdk.Tests/EscApiTests.cs`): replace `AssertFindEnvironment` with `await _client.GetEnvironmentAsync(...)` (throws on 404). Removed the now-unused helper.
- `CHANGELOG_PENDING.md` entry under Bug Fixes.

Net diff: -81 lines.

## Test plan

- [ ] All `test / Test *` jobs pass on this PR.
- [ ] After merge, #132 (`docs: fix occured typo in workspace error messages`) is unblocked.