### PR TITLE
ci: move GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -38,9 +38,9 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Extract Tag Name
         id: extract_tag
@@ -49,7 +49,7 @@ jobs:
           echo "::set-output name=tag_name::$TAG_NAME"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
 
       - name: Compute version
         id: ver

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
 
       - name: Compute version
         id: ver

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v3
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: pulumi/pulumictl
       - name: Set up Go 1.23

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.23.x
+          cache-dependency-path: sdk/go.sum
       - run: cd sdk && go mod tidy
       - name: Fail if go mod not tidy
         run: |
@@ -34,7 +35,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.0
+          version: v2.1
           working-directory: sdk
   lint_python:
     runs-on: ubuntu-latest
@@ -67,6 +68,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.23.x
+          cache-dependency-path: sdk/go.sum
       - name: Lint
         run: make lint-copyright
   check-sdk-generation-clean:

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up Go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: 1.23.x
       - run: cd sdk && go mod tidy
@@ -32,7 +32,7 @@ jobs:
       # The action doesn't have an install-only mode,
       # so we'll ask it to print its version only.
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.0
           working-directory: sdk
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: Install dependencies
@@ -58,13 +58,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v3
         with:
           repo: pulumi/pulumictl
       - name: Set up Go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: 1.23.x
       - name: Lint
@@ -73,12 +73,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
     - name: Generate SDKs
       uses: ./.github/actions/generate_sdk
 
     - name: Check worktree clean
-      uses: pulumi/git-status-check-action@v1
+      uses: pulumi/git-status-check-action@v2
 
     - run: git status --porcelain
       shell: bash

--- a/.github/workflows/stage-publish-sdk.yml
+++ b/.github/workflows/stage-publish-sdk.yml
@@ -30,11 +30,11 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -65,12 +65,12 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: version
         name: Set SDK Version
-        uses: pulumi/provider-version-action@v1
+        uses: pulumi/provider-version-action@v2
 
       - name: Generate SDKs
         uses: ./.github/actions/generate_sdk
@@ -96,16 +96,16 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - id: version
         name: Set SDK Version
-        uses: pulumi/provider-version-action@v1
+        uses: pulumi/provider-version-action@v2
       - name: Generate SDKs
         uses: ./.github/actions/generate_sdk
         env:
@@ -133,16 +133,16 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '6.0.x'
       - id: version
         name: Set SDK Version
-        uses: pulumi/provider-version-action@v1
+        uses: pulumi/provider-version-action@v2
       - name: Generate SDKs
         uses: ./.github/actions/generate_sdk
         env:

--- a/.github/workflows/stage-publish-sdk.yml
+++ b/.github/workflows/stage-publish-sdk.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Setup Node
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
       - id: version
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Set up Python
@@ -133,7 +133,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Setup .NET

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -31,13 +31,13 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit-ref }}
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           stable: ${{ matrix.go-stable }}
@@ -49,7 +49,7 @@ jobs:
         run: make test_go
       - name: Upload code coverage
         if: ${{ inputs.enable-coverage }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false
           verbose: true
@@ -66,9 +66,9 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit-ref }}
 
@@ -81,11 +81,11 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: Install dependencies
@@ -104,13 +104,13 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v2
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit-ref }}
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '6.0.x'
       - name: Test

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-          stable: ${{ matrix.go-stable }}
+          cache-dependency-path: sdk/go.sum
       - name: Test w/coverage
         if: ${{ inputs.enable-coverage }}
         run: make test_go_cover

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Set up Python
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Why
GitHub is deprecating the Node 20 actions runtime: runners force-migrate to Node 24 starting **2026-06-16**, and Node 20 is removed from runners on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Our release run surfaced these warnings across lint/test/publish.

## What
Bump every action to a current major that runs on Node 24:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v2 / v4 | **v6** |
| `actions/setup-go` | v2 / v3 | **v6** |
| `actions/setup-python` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `actions/setup-dotnet` | v4 | **v5** |
| `golangci/golangci-lint-action` | v7 | **v9** |
| `codecov/codecov-action` | v3 | **v7** |
| `jaxxstorm/action-install-gh-release` | v1.5.0 (node12) | **v3.0.0** |
| `softprops/action-gh-release` | v1 | **v3** |
| `pulumi/esc-action` | v1 | **v3** |
| `pulumi/provider-version-action` | v1 | **v2** |
| `pulumi/git-status-check-action` | v1 | **v2** |

`pulumi/publish-go-sdk-action` is intentionally left at **v1** — it's a composite (shell) action, so the Node 20 deprecation doesn't apply.

## Upstream Node 24 releases
The two Pulumi-owned Node 20 actions were bumped to Node 24 upstream and released as **v2.0.0** (mirroring `esc-action`):
- pulumi/provider-version-action#20 → `v2.0.0` ✅ merged
- pulumi/git-status-check-action#6 → `v2.0.0` ✅ merged

Both v2 majors resolve, so this PR is unblocked.

## Notes for review
- **`esc-action@v3`**: v3 is a breaking release upstream (installs the **Pulumi CLI** instead of the standalone ESC CLI; the `version` input now selects a Pulumi CLI version; later steps get `pulumi` on `PATH` instead of `esc`). **None of that affects this repo** — esc-action is used only to fetch/inject ESC secrets via OIDC: it pins no `version`, and no workflow step invokes the `esc` binary directly. Secret outputs (`PULUMI_BOT_TOKEN`, `NPM_TOKEN`, `CODECOV_TOKEN`, `SLACK_WEBHOOK_URL`) are injected the same way.
- `provider-version-action@v2` / `git-status-check-action@v2` differ from v1 only by the Node 24 runtime — no input/output contract changes.
- `jaxxstorm/action-install-gh-release` publishes only a floating `v1` tag (v2+ are exact-only), so it's pinned to the exact `v3.0.0`. The old `v1.5.0` was a `node12` action.
- `golangci-lint-action@v9` requires golangci-lint ≥ v2.1.0, so the lint pin moves `v2.0` → `v2.1`. The lint job passes clean on v2.1 (no new findings).
- `setup-go@v6` dropped the `stable` input (removed) and enables dependency caching by default; caching now points at `sdk/go.sum` since the module lives in `sdk/`.
- `codecov-action@v7`: tokenless upload still works for public repos and `fail_ci_if_error: false`, so an upload hiccup won't fail the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)